### PR TITLE
PWN-8075 - fixed layout for finance block row

### DIFF
--- a/ui-kit/src/main/kotlin/org/p2p/uikit/components/finance_block/UiKitFinanceBlockView.kt
+++ b/ui-kit/src/main/kotlin/org/p2p/uikit/components/finance_block/UiKitFinanceBlockView.kt
@@ -40,7 +40,10 @@ class UiKitFinanceBlockView @JvmOverloads constructor(
             right = paddingHorizontal,
             bottom = paddingVertical
         )
-        rippleForeground()
+        if(!isInEditMode) {
+            // editor preview crashes when trying to apply rippleForeground
+            rippleForeground()
+        }
         bindViewStyle(styleType)
     }
 

--- a/ui-kit/src/main/res/layout/widget_finance_block.xml
+++ b/ui-kit/src/main/res/layout/widget_finance_block.xml
@@ -20,7 +20,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/rightSideView"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
-        app:layout_constraintHorizontal_weight="0.8"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_goneMarginEnd="0dp" />
@@ -34,8 +33,6 @@
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_weight="0.25"
-        app:layout_constraintStart_toEndOf="@+id/leftSideView"
         app:layout_constraintTop_toTopOf="parent" />
 
 </merge>

--- a/ui-kit/src/main/res/layout/widget_right_side_double_text.xml
+++ b/ui-kit/src/main/res/layout/widget_right_side_double_text.xml
@@ -26,7 +26,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
-        tools:text="$190.91" />
+        tools:text="$10190.91" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textViewSecond"
@@ -44,7 +44,7 @@
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textViewFirst"
-        tools:text="23.8112 SOL"
+        tools:text="89088.8112 SOL"
         tools:visibility="visible" />
 
 </merge>


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-8075

## Description of Work

Fixed layout for `finance block`: removed horizontal chain to spread both views to full width
Also fixed editor crash while previewing `UiKitFinanceBlockView`

## Screenshots (Optional)

| Screenshot #1 | Screenshot #2 | Screenshot #3 |
|:-------------:|:-------------:|:-------------:|
| [Paste Pic 1] | [Paste Pic 2] | [Paste Pic 3] |
