### PR TITLE
PWN-7796 - fixed scientific notation for zero values

### DIFF
--- a/core/src/main/java/org/p2p/core/utils/AmountExtensions.kt
+++ b/core/src/main/java/org/p2p/core/utils/AmountExtensions.kt
@@ -74,8 +74,14 @@ fun BigDecimal.formatToken(decimals: Int = DEFAULT_DECIMAL): String = formatWith
 // case: 10000.000000007900 -> 100 000.00
 fun BigDecimal.formatTokenForMoonpay(): String = formatWithDecimals(MOONPAY_DECIMAL)
 
+/**
+ * Note: setScale(0) for zero is mandatory because if the value has precision greater than 6 decimals,
+ * the result of toString() will be formatted using scientific notation
+ * @param decimals - number of decimals to show
+ * @return formatted string
+ */
 private fun BigDecimal.formatWithDecimals(decimals: Int): String = this.stripTrailingZeros().run {
-    if (isZero()) this.toString() else DecimalFormatter.format(this, decimals)
+    if (isZero()) this.setScale(0).toString() else DecimalFormatter.format(this, decimals)
 }
 
 fun BigDecimal?.isNullOrZero(): Boolean = this == null || this.compareTo(BigDecimal.ZERO) == 0


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-7796

## Description of Work

Added `setScale(0)` before returning the zero string of BigDecimal. 
`BigDecimal.toString()` behaves differently on various android versions and apparently across different vendors.

