### PR TITLE
PWN-8245 - show rates loading warning in snackbar how it was before

### DIFF
--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
@@ -132,7 +132,14 @@ class HomePresenter(
                 view?.showRefreshing(true)
                 userInteractor.loadAllTokensDataIfEmpty()
                 val solTokens = userInteractor.loadUserTokensAndUpdateLocal(tokenKeyProvider.publicKey.toPublicKey())
-                async { userInteractor.loadUserRates(solTokens) }
+                async {
+                    try {
+                        userInteractor.loadUserRates(solTokens)
+                    } catch (t: Throwable) {
+                        Timber.e(t, "Error on loading Sol rates")
+                        view?.showUiKitSnackBar(messageResId = R.string.error_token_rates)
+                    }
+                }
                 async {
                     val bundles = ethereumInteractor.getListOfEthereumBundleStatuses()
                     ethereumInteractor.loadWalletTokens(bundles)

--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
@@ -136,7 +136,7 @@ class HomePresenter(
                     try {
                         userInteractor.loadUserRates(solTokens)
                     } catch (t: Throwable) {
-                        Timber.e(t, "Error on loading user rates")
+                        Timber.i(t, "Error on loading user rates")
                         view?.showUiKitSnackBar(messageResId = R.string.error_token_rates)
                     }
                 }

--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
@@ -136,7 +136,7 @@ class HomePresenter(
                     try {
                         userInteractor.loadUserRates(solTokens)
                     } catch (t: Throwable) {
-                        Timber.e(t, "Error on loading Sol rates")
+                        Timber.e(t, "Error on loading user rates")
                         view?.showUiKitSnackBar(messageResId = R.string.error_token_rates)
                     }
                 }


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-8245

## Description of Work

Reverted the snackbar error that occurs when unable to load token rates.
Originally, it was accidentially removed down there [link](https://github.com/p2p-org/key-app-android/pull/1547/files#diff-7d20ada08a280cc7d4172bc771d6c4a73602cb105ebd010f0f0aba4425fcc229L404)
