### PR TITLE
NO-TICKET - fix metadata initializer

### DIFF
--- a/app/src/main/java/org/p2p/wallet/auth/interactor/MetadataInteractor.kt
+++ b/app/src/main/java/org/p2p/wallet/auth/interactor/MetadataInteractor.kt
@@ -26,7 +26,7 @@ class MetadataInteractor(
     private val bridgeFeatureToggle: EthAddressEnabledFeatureToggle,
 ) {
 
-    var currentMetadata: GatewayOnboardingMetadata? = getMetadataFromStorage()
+    var currentMetadata: GatewayOnboardingMetadata? = null
         get() = getMetadataFromStorage()
         private set(value) {
             field = value


### PR DESCRIPTION
## Jira Ticket

~~https://p2pvalidator.atlassian.net/browse/~~

## Description of Work

Since EthereumKitRepository.init is only called after the object's construction, the default value should not be initialized during the construction process.
It leads to crash at the app starting process when koin initializes metadata dependencies