### PR TITLE
NO-TICKET - Fix removing redundant logs in Unit tests

### DIFF
--- a/app/src/test/java/org/p2p/wallet/auth/gateway/parser/CountryCodeXmlParserTest.kt
+++ b/app/src/test/java/org/p2p/wallet/auth/gateway/parser/CountryCodeXmlParserTest.kt
@@ -7,6 +7,7 @@ import io.michaelrocks.libphonenumber.android.PhoneNumberUtil
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertTrue
+import org.junit.ClassRule
 import org.junit.Test
 import java.io.File
 import java.io.InputStream
@@ -14,13 +15,15 @@ import java.nio.file.Paths
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.p2p.wallet.R
-import org.p2p.wallet.utils.plantTimberToStdout
+import org.p2p.wallet.utils.TimberUnitTestInstance
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CountryCodeXmlParserTest {
 
-    init {
-        plantTimberToStdout("CountryCodeXmlParserTest")
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance("CountryCodeXmlParserTest")
     }
 
     private val currentWorkingDir = Paths.get("").toAbsolutePath().toString()

--- a/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterBackPressTest.kt
+++ b/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterBackPressTest.kt
@@ -1,6 +1,7 @@
 package org.p2p.wallet.jupiter.ui.main
 
 import io.mockk.verify
+import org.junit.ClassRule
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -8,14 +9,16 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.p2p.wallet.utils.CoroutineExtension
 import org.p2p.wallet.utils.SpyOnInjectMockKsExtension
-import org.p2p.wallet.utils.plantTimberToStdout
+import org.p2p.wallet.utils.TimberUnitTestInstance
 
 @ExperimentalCoroutinesApi
 @ExtendWith(SpyOnInjectMockKsExtension::class, CoroutineExtension::class)
 class JupiterSwapPresenterBackPressTest : JupiterSwapPresenterBaseTest() {
 
-    init {
-        plantTimberToStdout(defaultTag = "Swap:BackPress")
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance("Swap:BackPress")
     }
 
     @Test

--- a/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterExecuteTransactionTest.kt
+++ b/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterExecuteTransactionTest.kt
@@ -3,6 +3,7 @@ package org.p2p.wallet.jupiter.ui.main
 import io.mockk.every
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.ClassRule
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.math.BigDecimal
@@ -16,16 +17,18 @@ import org.p2p.wallet.jupiter.ui.main.JupiterSwapTestHelpers.attachCallsLog
 import org.p2p.wallet.transaction.ui.SwapTransactionBottomSheetData
 import org.p2p.wallet.utils.CoroutineExtension
 import org.p2p.wallet.utils.SpyOnInjectMockKsExtension
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.back
 import org.p2p.wallet.utils.mutableListQueueOf
-import org.p2p.wallet.utils.plantTimberToStdout
 
 @ExperimentalCoroutinesApi
 @ExtendWith(SpyOnInjectMockKsExtension::class, CoroutineExtension::class)
 class JupiterSwapPresenterExecuteTransactionTest : JupiterSwapPresenterBaseTest() {
 
-    init {
-        plantTimberToStdout(
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance(
             defaultTag = "Swap:ExecuteTransaction",
             excludeMessages = listOf(
                 "kotlinx.coroutines.JobCancellationException"

--- a/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterInitialStateTest.kt
+++ b/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterInitialStateTest.kt
@@ -25,12 +25,12 @@ import org.p2p.wallet.utils.mutableListQueueOf
 
 @ExperimentalCoroutinesApi
 @ExtendWith(SpyOnInjectMockKsExtension::class, CoroutineExtension::class)
-class JupiterSwapPresenterInitialStateTest : JupiterSwapPresenterBaseTest()  {
+class JupiterSwapPresenterInitialStateTest : JupiterSwapPresenterBaseTest() {
 
     companion object {
         @ClassRule
         @JvmField
-        val timber = TimberUnitTestInstance(defaultTag = "Swap:InitialState",)
+        val timber = TimberUnitTestInstance(defaultTag = "Swap:InitialState")
     }
 
     @Test

--- a/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterInitialStateTest.kt
+++ b/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterInitialStateTest.kt
@@ -3,6 +3,7 @@ package org.p2p.wallet.jupiter.ui.main
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.ClassRule
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.math.BigDecimal
@@ -18,16 +19,18 @@ import org.p2p.wallet.jupiter.ui.main.JupiterSwapTestHelpers.attachCallsLog
 import org.p2p.wallet.jupiter.ui.main.widget.SwapWidgetModel
 import org.p2p.wallet.utils.CoroutineExtension
 import org.p2p.wallet.utils.SpyOnInjectMockKsExtension
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.back
 import org.p2p.wallet.utils.mutableListQueueOf
-import org.p2p.wallet.utils.plantTimberToStdout
 
 @ExperimentalCoroutinesApi
 @ExtendWith(SpyOnInjectMockKsExtension::class, CoroutineExtension::class)
-class JupiterSwapPresenterInitialStateTest : JupiterSwapPresenterBaseTest() {
+class JupiterSwapPresenterInitialStateTest : JupiterSwapPresenterBaseTest()  {
 
-    init {
-        plantTimberToStdout("Swap:InitialState")
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance(defaultTag = "Swap:InitialState",)
     }
 
     @Test

--- a/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterPriceImpactTest.kt
+++ b/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterPriceImpactTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.ClassRule
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.math.BigDecimal
@@ -13,16 +14,18 @@ import kotlinx.coroutines.test.runTest
 import org.p2p.wallet.jupiter.statemanager.price_impact.SwapPriceImpactView
 import org.p2p.wallet.utils.CoroutineExtension
 import org.p2p.wallet.utils.SpyOnInjectMockKsExtension
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.back
 import org.p2p.wallet.utils.mutableListQueueOf
-import org.p2p.wallet.utils.plantTimberToStdout
 
 @ExperimentalCoroutinesApi
 @ExtendWith(SpyOnInjectMockKsExtension::class, CoroutineExtension::class)
 class JupiterSwapPresenterPriceImpactTest : JupiterSwapPresenterBaseTest() {
 
-    init {
-        plantTimberToStdout(
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance(
             defaultTag = "Swap:PriceImpact",
             excludeMessages = listOf(
                 "kotlinx.coroutines.JobCancellationException"

--- a/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterTokenAmountChangeTest.kt
+++ b/app/src/test/java/org/p2p/wallet/jupiter/ui/main/JupiterSwapPresenterTokenAmountChangeTest.kt
@@ -3,6 +3,7 @@ package org.p2p.wallet.jupiter.ui.main
 import io.mockk.every
 import io.mockk.verify
 import org.junit.Assert.assertTrue
+import org.junit.ClassRule
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.math.BigDecimal
@@ -17,17 +18,19 @@ import org.p2p.wallet.jupiter.ui.main.JupiterSwapTestHelpers.attachCallsLog
 import org.p2p.wallet.jupiter.ui.main.widget.SwapWidgetModel
 import org.p2p.wallet.utils.CoroutineExtension
 import org.p2p.wallet.utils.SpyOnInjectMockKsExtension
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.back
 import org.p2p.wallet.utils.front
 import org.p2p.wallet.utils.mutableListQueueOf
-import org.p2p.wallet.utils.plantTimberToStdout
 
 @ExperimentalCoroutinesApi
 @ExtendWith(SpyOnInjectMockKsExtension::class, CoroutineExtension::class)
 class JupiterSwapPresenterTokenAmountChangeTest : JupiterSwapPresenterBaseTest() {
 
-    init {
-        plantTimberToStdout(
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance(
             defaultTag = "Swap:TokenAmountChange",
             excludeMessages = listOf(
                 "kotlinx.coroutines.JobCancellationException"

--- a/app/src/test/java/org/p2p/wallet/striga/signup/ui/StrigaSignupFirstStepPresenterTest.kt
+++ b/app/src/test/java/org/p2p/wallet/striga/signup/ui/StrigaSignupFirstStepPresenterTest.kt
@@ -16,6 +16,7 @@ import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
+import org.junit.ClassRule
 import org.junit.Test
 import java.io.File
 import java.io.InputStream
@@ -25,6 +26,8 @@ import kotlin.test.assertNotNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.p2p.core.common.di.AppScope
+import org.p2p.core.dispatchers.CoroutineDispatchers
 import org.p2p.wallet.R
 import org.p2p.wallet.auth.gateway.parser.CountryCodeXmlParser
 import org.p2p.wallet.auth.gateway.repository.model.GatewayOnboardingMetadata
@@ -33,9 +36,7 @@ import org.p2p.wallet.auth.model.CountryCode
 import org.p2p.wallet.auth.repository.CountryCodeInMemoryRepository
 import org.p2p.wallet.auth.repository.CountryCodeRepository
 import org.p2p.wallet.common.InAppFeatureFlags
-import org.p2p.core.common.di.AppScope
 import org.p2p.wallet.common.feature_toggles.toggles.inapp.StrigaSimulateWeb3Flag
-import org.p2p.core.dispatchers.CoroutineDispatchers
 import org.p2p.wallet.striga.model.StrigaDataLayerResult
 import org.p2p.wallet.striga.signup.StrigaSignUpFirstStepContract
 import org.p2p.wallet.striga.signup.interactor.StrigaSignupInteractor
@@ -47,10 +48,10 @@ import org.p2p.wallet.striga.signup.validation.PhoneNumberInputValidator
 import org.p2p.wallet.striga.signup.validation.StrigaSignupDataValidator
 import org.p2p.wallet.striga.user.interactor.StrigaUserInteractor
 import org.p2p.wallet.utils.TestAppScope
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.UnconfinedTestDispatchers
 import org.p2p.wallet.utils.back
 import org.p2p.wallet.utils.mutableListQueueOf
-import org.p2p.wallet.utils.plantTimberToStdout
 
 private val SupportedCountry = CountryCode(
     countryName = "United Kingdom",
@@ -97,8 +98,13 @@ class StrigaSignupFirstStepPresenterTest {
     private val appScope: AppScope = TestAppScope(dispatchers.ui)
 
     init {
-        plantTimberToStdout("StrigaSignupFirstStepPresenterTest")
         initCountryCodeLocalRepository()
+    }
+
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance("StrigaSignupFirstStepPresenterTest")
     }
 
     private fun createPresenter(): StrigaSignUpFirstStepPresenter {

--- a/app/src/test/java/org/p2p/wallet/striga/signup/ui/StrigaSignupSecondStepPresenterTest.kt
+++ b/app/src/test/java/org/p2p/wallet/striga/signup/ui/StrigaSignupSecondStepPresenterTest.kt
@@ -10,20 +10,21 @@ import io.mockk.verify
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.ClassRule
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.p2p.core.common.di.AppScope
+import org.p2p.core.dispatchers.CoroutineDispatchers
 import org.p2p.wallet.R
 import org.p2p.wallet.alarmlogger.logger.AlarmErrorsLogger
 import org.p2p.wallet.auth.interactor.MetadataInteractor
 import org.p2p.wallet.auth.model.CountryCode
 import org.p2p.wallet.auth.repository.CountryCodeRepository
 import org.p2p.wallet.common.InAppFeatureFlags
-import org.p2p.core.common.di.AppScope
 import org.p2p.wallet.common.feature_toggles.toggles.inapp.StrigaSimulateWeb3Flag
-import org.p2p.core.dispatchers.CoroutineDispatchers
 import org.p2p.wallet.striga.model.StrigaDataLayerResult
 import org.p2p.wallet.striga.onboarding.interactor.StrigaOnboardingInteractor
 import org.p2p.wallet.striga.presetpicker.interactor.StrigaPresetDataItem
@@ -39,10 +40,10 @@ import org.p2p.wallet.striga.signup.repository.model.StrigaSignupDataType
 import org.p2p.wallet.striga.signup.validation.StrigaSignupDataValidator
 import org.p2p.wallet.striga.user.interactor.StrigaUserInteractor
 import org.p2p.wallet.utils.TestAppScope
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.UnconfinedTestDispatchers
 import org.p2p.wallet.utils.back
 import org.p2p.wallet.utils.mutableListQueueOf
-import org.p2p.wallet.utils.plantTimberToStdout
 
 private val SupportedCountry = CountryCode(
     countryName = "United Kingdom",
@@ -84,8 +85,10 @@ class StrigaSignupSecondStepPresenterTest {
     private val dispatchers: CoroutineDispatchers = UnconfinedTestDispatchers()
     private val appScope: AppScope = TestAppScope(dispatchers.ui)
 
-    init {
-        plantTimberToStdout("StrigaSignupSecondStepPresenterTest")
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance("StrigaSignupSecondStepPresenterTest")
     }
 
     private fun createPresenter(): StrigaSignUpSecondStepPresenter {

--- a/app/src/test/java/org/p2p/wallet/striga/signup/validation/PhoneNumberInputValidatorTest.kt
+++ b/app/src/test/java/org/p2p/wallet/striga/signup/validation/PhoneNumberInputValidatorTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.ClassRule
 import org.junit.Test
 import java.io.File
 import java.io.InputStream
@@ -22,12 +23,14 @@ import org.p2p.wallet.auth.gateway.parser.CountryCodeXmlParser
 import org.p2p.wallet.auth.repository.CountryCodeInMemoryRepository
 import org.p2p.wallet.auth.repository.CountryCodeRepository
 import org.p2p.wallet.utils.TestCoroutineDispatchers
-import org.p2p.wallet.utils.plantTimberToStdout
+import org.p2p.wallet.utils.TimberUnitTestInstance
 
 class PhoneNumberInputValidatorTest {
 
-    init {
-        plantTimberToStdout("PhoneNumberInputValidatorTest")
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance("PhoneNumberInputValidatorTest")
     }
 
     @Before

--- a/app/src/test/java/org/p2p/wallet/striga/user/StrigaStorageTest.kt
+++ b/app/src/test/java/org/p2p/wallet/striga/user/StrigaStorageTest.kt
@@ -7,6 +7,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.ClassRule
 import org.junit.Test
 import java.math.BigDecimal
 import org.p2p.core.BuildConfig
@@ -20,13 +21,15 @@ import org.p2p.core.network.gson.Base64TypeAdapter
 import org.p2p.core.network.gson.BigDecimalTypeAdapter
 import org.p2p.wallet.striga.user.model.StrigaUserStatusDetails
 import org.p2p.wallet.striga.user.model.StrigaUserVerificationStatus
+import org.p2p.wallet.utils.TimberUnitTestInstance
 import org.p2p.wallet.utils.assertThat
-import org.p2p.wallet.utils.plantTimberToStdout
 
 class StrigaStorageTest {
 
-    init {
-        plantTimberToStdout("StrigaStorageTest")
+    companion object {
+        @ClassRule
+        @JvmField
+        val timber = TimberUnitTestInstance("StrigaStorageTest")
     }
 
     private val gson: Gson

--- a/app/src/test/java/org/p2p/wallet/utils/TimberTestUtils.kt
+++ b/app/src/test/java/org/p2p/wallet/utils/TimberTestUtils.kt
@@ -1,12 +1,27 @@
 package org.p2p.wallet.utils
 
 import android.util.Log
+import org.junit.rules.ExternalResource
 import timber.log.Timber
 import java.io.PrintStream
 
 private fun Int.toPrinter(): PrintStream = when {
     this == Log.WARN || this == Log.ERROR || this == Log.ASSERT -> System.err
     else -> System.out
+}
+
+// usage example:
+//companion object {
+//    @ClassRule
+//    val timber = TimberUnitTestInstance("CountryCodeXmlParserTest")
+//}
+class TimberUnitTestInstance(
+    private val defaultTag: String,
+    private val excludeMessages: List<String> = emptyList(),
+    private val excludeStacktraceForMessages: List<String> = emptyList()
+) : ExternalResource() {
+    override fun before() = plantTimberToStdout(defaultTag, excludeMessages, excludeStacktraceForMessages)
+    override fun after() = Timber.uprootAll()
 }
 
 fun plantStubTimber() {

--- a/app/src/test/java/org/p2p/wallet/utils/TimberTestUtils.kt
+++ b/app/src/test/java/org/p2p/wallet/utils/TimberTestUtils.kt
@@ -10,11 +10,11 @@ private fun Int.toPrinter(): PrintStream = when {
     else -> System.out
 }
 
-//companion object {
+// companion object {
 //    @ClassRule
 //    @JvmField
 //    val timber = TimberUnitTestInstance("Swap:BackPress")
-//}
+// }
 /**
  * ^ example of usage ^
  * should be PUBLIC, JVMFIELD and STATIC

--- a/app/src/test/java/org/p2p/wallet/utils/TimberTestUtils.kt
+++ b/app/src/test/java/org/p2p/wallet/utils/TimberTestUtils.kt
@@ -10,11 +10,16 @@ private fun Int.toPrinter(): PrintStream = when {
     else -> System.out
 }
 
-// usage example:
 //companion object {
 //    @ClassRule
-//    val timber = TimberUnitTestInstance("CountryCodeXmlParserTest")
+//    @JvmField
+//    val timber = TimberUnitTestInstance("Swap:BackPress")
 //}
+/**
+ * ^ example of usage ^
+ * should be PUBLIC, JVMFIELD and STATIC
+ * plants and removes printing to STDOUT and STDERR
+ */
 class TimberUnitTestInstance(
     private val defaultTag: String,
     private val excludeMessages: List<String> = emptyList(),
@@ -28,7 +33,7 @@ fun plantStubTimber() {
     Timber.plant(object : Timber.DebugTree() {})
 }
 
-fun plantTimberToStdout(
+private fun plantTimberToStdout(
     defaultTag: String,
     excludeMessages: List<String> = emptyList(),
     excludeStacktraceForMessages: List<String> = emptyList()


### PR DESCRIPTION
after planting timber it was not uprooting so every timber logged in console a lot of stuff