### PR TITLE
NO-TICKET - Striga. Load statement only on calculator

### DIFF
--- a/app/src/main/java/org/p2p/wallet/striga/offramp/ui/StrigaOffRampPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/striga/offramp/ui/StrigaOffRampPresenter.kt
@@ -179,8 +179,10 @@ class StrigaOffRampPresenter(
         launch {
             try {
                 // load all necessary data again if it was not loaded before
-                // enrich crypto + enrich EUR + load statement to extract iban & bic
+                // enrich crypto + enrich EUR
                 strigaWalletInteractor.loadDetailsForStrigaAccounts().getOrThrow()
+                // load statement to extract iban & bic
+                strigaWalletInteractor.getEurBankingDetails()
 
                 // go to withdraw screen
                 view?.navigateToWithdraw(inputAmountA)

--- a/app/src/main/java/org/p2p/wallet/striga/user/storage/StrigaStorage.kt
+++ b/app/src/main/java/org/p2p/wallet/striga/user/storage/StrigaStorage.kt
@@ -99,6 +99,8 @@ class StrigaStorage(
         userStatus = null
         userWallet = null
         fiatAccount = null
+        cryptoAccount = null
+        bankingDetails = null
         smsExceededVerificationAttemptsMillis = 0
         smsExceededResendAttemptsMillis = 0
 

--- a/app/src/main/java/org/p2p/wallet/striga/wallet/interactor/StrigaWalletInteractor.kt
+++ b/app/src/main/java/org/p2p/wallet/striga/wallet/interactor/StrigaWalletInteractor.kt
@@ -29,7 +29,6 @@ class StrigaWalletInteractor(
     suspend fun loadDetailsForStrigaAccounts(): Result<Unit> = kotlin.runCatching {
         getFiatAccountDetails()
         getCryptoAccountDetails()
-        getEurBankingDetails()
         Unit
     }.onFailure {
         Timber.e(it, "Unable to load striga accounts (fiat and crypto) details")


### PR DESCRIPTION
## Description of Work

Don't load striga account statement when app starts, instead it should be loaded on "next" button in striga off-ramp calculator
