### PR TITLE
PWN-9504 - fix setting metadata from memory if not InitialTokensLoaded

### DIFF
--- a/app/src/main/java/org/p2p/wallet/user/interactor/TokenMetadataInteractor.kt
+++ b/app/src/main/java/org/p2p/wallet/user/interactor/TokenMetadataInteractor.kt
@@ -33,6 +33,9 @@ class TokenMetadataInteractor(
             }
             is UpdateTokenMetadataResult.Error -> {
                 handleError(result.throwable)
+                if (!userLocalRepository.areInitialTokensLoaded()) {
+                    updateMemoryCache(metadataFromFile)
+                }
             }
         }
     }

--- a/token-service/src/main/java/org/p2p/token/service/repository/metadata/TokenMetadataRemoteRepository.kt
+++ b/token-service/src/main/java/org/p2p/token/service/repository/metadata/TokenMetadataRemoteRepository.kt
@@ -44,6 +44,8 @@ internal class TokenMetadataRemoteRepository(
             } else {
                 UpdateTokenMetadataResult.Error(e)
             }
+        } catch (e: Throwable) {
+            return@withContext UpdateTokenMetadataResult.Error(e)
         }
 
         val responseBody = response.body() ?: return@withContext UpdateTokenMetadataResult.NoUpdate


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-9504

## Description of Work

PWN-9504 - fix setting metadata from memory if not InitialTokensLoaded