### PR TITLE
ETH-636 - added support for trailing dot in swapwidget when comparing amounts

### DIFF
--- a/app/src/main/java/org/p2p/wallet/jupiter/ui/main/widget/SwapWidget.kt
+++ b/app/src/main/java/org/p2p/wallet/jupiter/ui/main/widget/SwapWidget.kt
@@ -143,13 +143,13 @@ class SwapWidget @JvmOverloads constructor(
         editTextAmount.setReadOnly(readOnly, inputType)
         val amountMaxDecimals = model.amountMaxDecimals ?: DEFAULT_DECIMAL
         updateFormatter(amountMaxDecimals)
+        val oldAmountRaw = editTextAmount.text?.toString() ?: emptyString()
         val newAmountRaw = (newAmount as? TextViewCellModel.Raw)?.text?.getString(context)
-        val oldAMountRaw = editTextAmount.text?.toString() ?: emptyString()
         val newTextColorRes = (newAmount as? TextViewCellModel.Raw)?.textColor
         val oldTextColorRes = (currentAmountCell as? TextViewCellModel.Raw)?.textColor
         internalOnAmountChanged = null
         if (currentAmountCell is TextViewCellModel.Skeleton ||
-            newAmountRaw != oldAMountRaw ||
+            checkAmountsAreNotEqualExcludingTrailingDot(newAmountRaw, oldAmountRaw) ||
             newTextColorRes != oldTextColorRes
         ) {
             editTextAmount.bindOrGone(newAmount, force = true)
@@ -213,5 +213,16 @@ class SwapWidget @JvmOverloads constructor(
             getColor(R.color.text_silver),
         )
         return ColorStateList(states, colors)
+    }
+
+    /**
+     * Consider two amounts are not equal if they are not equal excluding trailing dot.
+     * We should respect trailing dot in user input as it can be used to enter fractional part.
+     * Example: 6. == 6; 6.0 != 6; 6.0 == 6.0
+     */
+    private fun checkAmountsAreNotEqualExcludingTrailingDot(a: String?, b: String?): Boolean {
+        val aWithoutTrailingDot = a?.removeSuffix(".")
+        val bWithoutTrailingDot = b?.removeSuffix(".")
+        return aWithoutTrailingDot != bWithoutTrailingDot
     }
 }


### PR DESCRIPTION
## Jira Ticket

https://linear.app/etherean/issue/ETH-650/[android]-key-app-swap-nevozmozhno-vvesti-drobnoe-chislo-pri-bystrom

## Description of Work

[ what work was done in this ticket ]

## Screenshots (Optional)

| Screenshot #1 | Screenshot #2 | Screenshot #3 |
|:-------------:|:-------------:|:-------------:|
| [Paste Pic 1] | [Paste Pic 2] | [Paste Pic 3] |
